### PR TITLE
K8S 1.22: Fix CRD API version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     kubeconfig: "{{ kube_defaults_kubeconfig }}"
     definition:
       kind: ClusterRoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1beta1
+      apiVersion: rbac.authorization.k8s.io/v1
       metadata:
         name: kube-apiserver-to-kubelet
       subjects:


### PR DESCRIPTION
This just bumps the API version so that this still works on K8S 1.22+
